### PR TITLE
Fixed some small bugs on home page

### DIFF
--- a/app/assets/stylesheets/components/_card_home_page.scss
+++ b/app/assets/stylesheets/components/_card_home_page.scss
@@ -1,9 +1,10 @@
 .credit-card {
   overflow: hidden;
-  width: 600px;
+  width: 650px;
   background: white;
   box-shadow: 0 0 15px rgba(0,0,0,0.2);
-  margin-bottom: 20px;
+  margin: 0 auto 20px auto;
+  max-width: 100%;
 }
 
 .credit-card > img {
@@ -30,4 +31,11 @@
   justify-content: space-between;
   align-items: flex-end;
   position: relative;
+}
+
+.credit-card .card-trip-user {
+  position: absolute;
+  right: 16px;
+  top: -20px;
+  width: 40px;
 }

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -3,7 +3,7 @@
 .banner {
   background-size: cover;
   background-position: center;
-  padding: 150px 0;
+  padding: 120px 0;
 }
 
 .banner h1 {
@@ -20,8 +20,19 @@
   text-shadow: 1px 1px 3px rgba(0,0,0,0.2);
 }
 
-h2 {
+h2.extra-big {
   font-size: 65px;
-  color: black;
+  color: $gray;
   text-shadow: 1px 1px 3px rgba(0,0,0,0.2);
+}
+
+@media screen and (max-width: 1400px) {
+  h2.extra-big {
+    font-size: 45px;
+  }
+}
+@media screen and (max-width: 992px) {
+  h2.extra-big {
+    font-size: 36px;
+  }
 }

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -2,7 +2,7 @@
   <div class="container">
     <h1>Credify <strong> Unlock your spending potential </strong> with <strong>Thousands of credit cards for rent</strong>!</h1>
     <p>Change your life, Use Credify</p>
-    <%= link_to "Sign up", "#", class: "btn btn-gradient" %>
+    <%= link_to "Sign up", new_user_registration_path, class: "btn btn-gradient" %>
   </div>
 </div>
 

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,70 +1,68 @@
-
-
 <div class="banner" style="background-image: linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4)), url(https://realtytax.ca/wp-content/uploads/2021/07/Credit-Card-Visa-Master-Card.jpg);">
   <div class="container">
-    <h1>Credify <strong> Unlock your spending potential! </strong> with <strong>Thousands of credit cards for rent</strong>!</h1>
+    <h1>Credify <strong> Unlock your spending potential </strong> with <strong>Thousands of credit cards for rent</strong>!</h1>
     <p>Change your life, Use Credify</p>
     <%= link_to "Sign up", "#", class: "btn btn-gradient" %>
   </div>
 </div>
 
 <div class= "container py-5">
-
-      <h2><Strong>Find a Card that Suits your needs Today!!!</Strong></h2>
-
-<div class= "row justify-content-center py-3">
-  <div class= "col-12 col-lg-6">
-    <div class="credit-card">
-      <img src="https://www.costco.ca/wcsstore/CostcoCABCCatalogAssetStore/feature-pages/17w1217-membership-card-executive.png" />
-      <div class="card-trip-infos">
-        <div>
-          <h2>Costco Card</h2>
-          <p>Make your trips to Costco worth it!</p>
-        </div>
-        <h2 class="card-trip-pricing">$50</h2>
-        <img src="https://kitt.lewagon.com/placeholder/users/krokrob" class="card-trip-user avatar-bordered" />
-      </div>
-    </div>
-</div>
-
-<div class= "col-12 col-lg-6">
-  <div class="credit-card">
-    <img src="https://cdn.corporate.walmart.com/dims4/WMT/4f9552e/2147483647/strip/true/crop/1125x750+0+0/resize/1960x1306!/quality/90/?url=https%3A%2F%2Fcdn.corporate.walmart.com%2Fd2%2Fec%2Fbe9650a94452a421323ffa56a289%2Fwalmart-credit-card.PNG" />
-    <div class="card-trip-infos">
-      <div>
-        <h2>Walmart Card</h2>
-        <p>Groceries that change life!</p>
-      </div>
-      <h2 class="card-trip-pricing">$80</h2>
-      <img src="https://kitt.lewagon.com/placeholder/users/krokrob" class="card-trip-user avatar-bordered" />
-      </div>
-  </div>
-</div>
-
-<div class= "col-12 col-lg-6">
-  <div class="credit-card">
-    <img src="https://c1.neweggimages.com/ProductImage/32-703-002CVF~004CVF.JPG" />
-     <div class="card-trip-infos">
-      <div>
-        <h2>Air Canada Card</h2>
-        <p>A new way to fly!</p>
-      </div>
-        <h2 class="card-trip-pricing">$90</h2>
-        <img src="https://kitt.lewagon.com/placeholder/users/krokrob" class="card-trip-user avatar-bordered" />
-      </div>
-  </div>
-</div>
-
-<div class= "col-12 col-lg-6">
-  <div class="credit-card">
-      <img src="https://www.storefrontdirect.com/pub/media/catalog/product/cache/8c0cd180e440eae853fa2176b62a6ddf/p/p/ppx_high_res_generic_1.png" />
-      <div class="card-trip-infos">
-        <div>
-          <h2>Pharmaprix Card</h2>
-          <p>A new pharmacy shoping experience!</p>
-        </div>
-          <h2 class="card-trip-pricing">$100</h2>
+  <h2 class="extra-big"><strong>Find a Card that Suits your needs Today!!!</strong></h2>
+  <div class= "row justify-content-center py-3">
+    <div class= "col-12 col-lg-6">
+      <div class="credit-card">
+        <img src="https://www.costco.ca/wcsstore/CostcoCABCCatalogAssetStore/feature-pages/17w1217-membership-card-executive.png" />
+        <div class="card-trip-infos">
+          <div>
+            <h2>Costco Card</h2>
+            <p>Make your trips to Costco worth it!</p>
+          </div>
+          <h2 class="card-trip-pricing">$50</h2>
           <img src="https://kitt.lewagon.com/placeholder/users/krokrob" class="card-trip-user avatar-bordered" />
         </div>
+      </div>
     </div>
+
+    <div class= "col-12 col-lg-6">
+      <div class="credit-card">
+        <img src="https://cdn.corporate.walmart.com/dims4/WMT/4f9552e/2147483647/strip/true/crop/1125x750+0+0/resize/1960x1306!/quality/90/?url=https%3A%2F%2Fcdn.corporate.walmart.com%2Fd2%2Fec%2Fbe9650a94452a421323ffa56a289%2Fwalmart-credit-card.PNG" />
+        <div class="card-trip-infos">
+          <div>
+            <h2>Walmart Card</h2>
+            <p>Groceries that change life!</p>
+          </div>
+          <h2 class="card-trip-pricing">$80</h2>
+          <img src="https://kitt.lewagon.com/placeholder/users/krokrob" class="card-trip-user avatar-bordered" />
+        </div>
+      </div>
+    </div>
+
+    <div class= "col-12 col-lg-6">
+      <div class="credit-card">
+        <img src="https://c1.neweggimages.com/ProductImage/32-703-002CVF~004CVF.JPG" />
+        <div class="card-trip-infos">
+          <div>
+            <h2>Air Canada Card</h2>
+            <p>A new way to fly!</p>
+          </div>
+          <h2 class="card-trip-pricing">$90</h2>
+          <img src="https://kitt.lewagon.com/placeholder/users/krokrob" class="card-trip-user avatar-bordered" />
+        </div>
+      </div>
+    </div>
+
+    <div class= "col-12 col-lg-6">
+      <div class="credit-card">
+        <img src="https://www.storefrontdirect.com/pub/media/catalog/product/cache/8c0cd180e440eae853fa2176b62a6ddf/p/p/ppx_high_res_generic_1.png" />
+        <div class="card-trip-infos">
+          <div>
+            <h2>Pharmaprix Card</h2>
+            <p>A new pharmacy shoping experience!</p>
+          </div>
+            <h2 class="card-trip-pricing">$100</h2>
+            <img src="https://kitt.lewagon.com/placeholder/users/krokrob" class="card-trip-user avatar-bordered" />
+        </div>
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
I added some styling fixes for the homepage cards (mostly spacing and a couple of media queries to make the h2 smaller in some devices), removed the padding on the banner a little bit (as per @SaneCashew's suggestion, it does look better) and added 2 closing divs at the end of the _home.html.erb to fix the footer. I also fixed the indentation to make it easier to read, but github reads it like it was changed a lot (sorry about that).

BTW, the class on the H2 will fix the login and signup titles looking too big.

This is how the homepage is looking now in my branch:
![Screen Shot 2022-11-03 at 10 25 26 PM](https://user-images.githubusercontent.com/108884517/199871787-35ef4b1d-6ef7-4ec0-ad6d-2d323b759507.png)
